### PR TITLE
fix eject failing randomly

### DIFF
--- a/src/renderer/ship/Ship.tsx
+++ b/src/renderer/ship/Ship.tsx
@@ -31,8 +31,15 @@ export const Ship: React.FC = () => {
         }
     })
     const { mutate: ejectShip, isLoading } = useMutation(async () => {
-        await send('stop-pier', ship)
-        return send('eject-pier', ship)
+        const pier = await send('stop-pier', ship)
+
+        //we wait here in case .vere.lock hasn't cleared yet (race condition)
+        return new Promise<void>((resolve) => {
+            setTimeout(async () => {
+                await send('eject-pier', pier)
+                resolve();
+            }, 2000)
+        })
     }, {
         onSuccess: () => {
             queryClient.prefetchQuery(pierKey())


### PR DESCRIPTION
Sometimes `.vere.lock` takes a little longer to clean up than the actual point where the ship stops so there's race condition. This branch should fix #42.