### PR TITLE
Better m1 check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "port",
   "productName": "Port",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A ship runner and manager for Urbit OS",
   "repository": {
     "type": "git",

--- a/src/background/main.ts
+++ b/src/background/main.ts
@@ -1,7 +1,7 @@
 import { exec } from 'child_process';
 import db from './db';
 import { platform, arch } from 'os';
-import { HandlerEntry, HandlerMap, init, send } from './server/ipc';
+import { Handler, HandlerEntry, HandlerMap, init, send } from './server/ipc';
 import { OSHandlers, OSService } from './services/os-service';
 import { PierHandlers, PierService } from './services/pier-service';
 import { ipcRenderer } from 'electron';
@@ -10,7 +10,7 @@ import { portPierMigration } from './migrations/port-migration';
 
 start();
 
-export type Handlers = OSHandlers & PierHandlers//& { init: () => Promise<PierData> };
+export type Handlers = OSHandlers & PierHandlers & { connected: Handler }//& { init: () => Promise<PierData> };
 
 async function start() {
     const handlerMap: HandlerMap<Handlers> = {} as HandlerMap<Handlers>;
@@ -48,18 +48,23 @@ async function architectureSupportCheck() {
     
     try {
         if (osPlatform === 'darwin') {
-            const isM1 = await new Promise((resolve) => {
+            const sysctlCheck = await new Promise((resolve) => {
                 exec('sysctl sysctl.proc_translated', (error, stdout, stderr) => {
                     if (error || stderr) {
                         resolve(false);
                     }
 
-                    const isTranslated = !!(stdout.trim().slice(-1));
-                    resolve(isTranslated);
+                    resolve(!stdout.includes('unknown'));
                 })
             });
 
-            if (osArch === 'arm64' || isM1) {
+            const archCheck = await new Promise((resolve) => {
+                exec('arch', (error, stdout, stderr) => {
+                    resolve(stdout.includes('arm64'))
+                })
+            })
+
+            if (osArch === 'arm64' || archCheck || sysctlCheck) {
                 await send('arch-unsupported', osPlatform + '-' + osArch);
             }
         }

--- a/src/main/main-window.ts
+++ b/src/main/main-window.ts
@@ -275,8 +275,8 @@ export function createMainWindow(
   });
   mainWindow.webContents.session.clearCache();
   osHelperStart(mainWindow, createNewWindow, bgWindow)
+  isDev && mainWindow.webContents.openDevTools();
   mainWindow.loadURL(mainUrl);
-
   //mainWindow.on('new-tab' as any, () => createNewTab(mainUrl, true));
 
   mainWindow.on('close', (event) => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -82,7 +82,10 @@ const App = () => {
         const listeners = [
             listen('piers-migrating', () => useStore.setState({ migrationStatus: 'migrating' })),
             listen('piers-migrated', () => useStore.setState({ migrationStatus: 'migrated' })),
-            listen('arch-unsupported', ({ architectureUnsupported }) => useStore.setState({ architectureUnsupported }))
+            listen('arch-unsupported', (architectureUnsupported) => {
+                console.log({ architectureUnsupported })
+                useStore.setState({ architectureUnsupported })
+            })
         ]
 
         return () => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -31,6 +31,7 @@ const queryClient = new QueryClient({
 export const useStore = create(() => ({
     piers: [],
     architectureUnsupported: null,
+    archCheckOpen: true,
     updateStatus: 'initial',
     migrationStatus: 'initial',
     zoomLevels: {

--- a/src/renderer/client/ipc.ts
+++ b/src/renderer/client/ipc.ts
@@ -20,6 +20,7 @@ export async function init(): Promise<void> {
 // State
 const replyHandlers = new Map<string, ReplyHandler>()
 const listeners = new Map<string, Listener[]>()
+let serverConnected = false;
 let messageQueue: Stringified<ServerMessage<Handlers>>[] = []
 let socketClient: Client = null
 
@@ -70,12 +71,25 @@ function handleResponse(msg: Reply | Error): void {
 
 function onConnect(client: Client, onOpen: () => void): void {
     socketClient = client
+    socketClient.emit('message', JSON.stringify({
+        id: v4(),
+        name: 'connected',
+        args: []
+    }));
 
-    // Send any messages that were queued while closed
-    if (messageQueue.length > 0) {
-        messageQueue.forEach(msg => client.emit('message', msg))
-        messageQueue = []
-    }
+    listen('connected', () => {
+        if (serverConnected) {
+            return;
+        }
+        
+        serverConnected = true;
+        send('connected');
+        // Send any messages that were queued while closed
+        if (messageQueue.length > 0) {
+            messageQueue.forEach(msg => client.emit('message', msg))
+            messageQueue = []
+        }
+    })
 
     onOpen();
 }
@@ -89,12 +103,12 @@ export function send<T extends keyof Handlers>(name: T, ...args: Parameters<Hand
         const msg: ServerMessage<Handlers> = { id, name, args };
         const stringMsg = JSON.stringify(msg);
 
-        console.log(Date.now(), 'client sending:', msg);
         
         replyHandlers.set(id, { resolve, reject })
-
-        if (socketClient) {
+        
+        if (socketClient && serverConnected) {
             socketClient.emit('message', stringMsg)
+            console.log(Date.now(), 'client sending:', msg);
         } else {
             messageQueue.push(stringMsg)
         }

--- a/src/renderer/shared/Layout.tsx
+++ b/src/renderer/shared/Layout.tsx
@@ -57,23 +57,25 @@ export const Layout: FunctionComponent<LayoutProps> = ({ children, title, center
                 </header>
             }
             <main className={`grid ${center ? 'justify-center content-center' : ''} ${isOSX() ? 'mt-7' : ''} ${className}`}>
-                <Dialog defaultOpen={archUnsupported}>
-                    <DialogContent 
-                        showCloseIcon={false}
-                        onOpenAutoFocus={e => e.preventDefault()}
-                        onEscapeKeyDown={e => e.preventDefault()}
-                        onPointerDownOutside={e => e.preventDefault()} 
-                        className="p-6 space-y-3"
-                    >
-                        <h2 className="font-semibold">Apple M1 Unsupported</h2>
-                        <p>While Port itself can run on Apple M1 architecture, Urbit itself cannot yet. This <a href="https://github.com/urbit/urbit/issues/4257">issue</a> may give more insight.</p>
-                        <p className="flex flex-end">
-                            <Button onClick={() => send('quit')}>
-                                <Close className="w-7 h-7" primary="fill-current" /> Quit
-                            </Button>
-                        </p>
-                    </DialogContent>
-                </Dialog>
+                {archUnsupported &&
+                    <Dialog defaultOpen={true}>
+                        <DialogContent 
+                            showCloseIcon={false}
+                            onOpenAutoFocus={e => e.preventDefault()}
+                            onEscapeKeyDown={e => e.preventDefault()}
+                            onPointerDownOutside={e => e.preventDefault()} 
+                            className="p-6 space-y-3"
+                        >
+                            <h2 className="font-semibold">Apple M1 Unsupported</h2>
+                            <p>While Port itself can run on Apple M1 architecture, Urbit itself cannot yet. This <a href="https://github.com/urbit/urbit/issues/4257">issue</a> may give more insight.</p>
+                            <p className="flex flex-end">
+                                <Button onClick={() => send('quit')}>
+                                    <Close className="w-7 h-7" primary="fill-current" /> Quit
+                                </Button>
+                            </p>
+                        </DialogContent>
+                    </Dialog>
+                }
                 { children }
             </main>
             <footer className="flex items-center h-8 py-2 z-20">

--- a/src/renderer/shared/Layout.tsx
+++ b/src/renderer/shared/Layout.tsx
@@ -8,7 +8,7 @@ import { UpdateNotifier } from './UpdateNotifier';
 import { useStore } from '../App';
 import { Spinner } from './Spinner';
 import { Close } from '../icons/Close';
-import { Dialog, DialogContent } from './Dialog';
+import { Dialog, DialogClose, DialogContent } from './Dialog';
 import { Button } from './Button';
 
 interface LayoutProps {
@@ -22,8 +22,15 @@ export const Layout: FunctionComponent<LayoutProps> = ({ children, title, center
     const history = useHistory();
     const url = stringifyHistory();
     const zoomLevels = useStore(state => state.zoomLevels);
-    const migrationStatus = useStore(state => state.migrationStatus);
-    const archUnsupported = useStore(state => state.architectureUnsupported);
+    const { 
+        migrationStatus,
+        archCheckOpen,
+        architectureUnsupported 
+    } = useStore(state => ({ 
+        migrationStatus: state.migrationStatus,
+        archCheckOpen: state.archCheckOpen,
+        architectureUnsupported: state.architectureUnsupported
+    }));
     const [showDevTools, setShowDevTools] = useState(false);
 
     useEffect(() => {
@@ -57,21 +64,23 @@ export const Layout: FunctionComponent<LayoutProps> = ({ children, title, center
                 </header>
             }
             <main className={`grid ${center ? 'justify-center content-center' : ''} ${isOSX() ? 'mt-7' : ''} ${className}`}>
-                {archUnsupported &&
-                    <Dialog defaultOpen={true}>
+                {architectureUnsupported &&
+                    <Dialog open={archCheckOpen} onOpenChange={open => useStore.setState({ archCheckOpen: open })}>
                         <DialogContent 
                             showCloseIcon={false}
                             onOpenAutoFocus={e => e.preventDefault()}
                             onEscapeKeyDown={e => e.preventDefault()}
                             onPointerDownOutside={e => e.preventDefault()} 
-                            className="p-6 space-y-3"
                         >
                             <h2 className="font-semibold">Apple M1 Unsupported</h2>
-                            <p>While Port itself can run on Apple M1 architecture, Urbit itself cannot yet. We're actively working on a solution, which is being tracked in this <a href="https://github.com/urbit/urbit/issues/4257">issue</a>.</p>
-                            <p className="flex flex-end">
+                            <p className="mt-3">While Port itself can run on Apple M1 architecture, Urbit itself cannot yet. We're actively working on a solution, which is being tracked in this <a href="https://github.com/urbit/urbit/issues/4257">issue</a>. However, you can still use Port to connect to a remote, hosted ship.</p>
+                            <p className="flex justify-end space-x-4 mt-6">
                                 <Button onClick={() => send('quit')}>
-                                    <Close className="w-7 h-7" primary="fill-current" /> Quit
+                                    <Close className="w-6 h-6 -ml-1" primary="fill-current" /> Quit Port
                                 </Button>
+                                <DialogClose as={Button}>
+                                    I understand, Proceed anyway
+                                </DialogClose>
                             </p>
                         </DialogContent>
                     </Dialog>

--- a/src/renderer/shared/Layout.tsx
+++ b/src/renderer/shared/Layout.tsx
@@ -67,7 +67,7 @@ export const Layout: FunctionComponent<LayoutProps> = ({ children, title, center
                             className="p-6 space-y-3"
                         >
                             <h2 className="font-semibold">Apple M1 Unsupported</h2>
-                            <p>While Port itself can run on Apple M1 architecture, Urbit itself cannot yet. This <a href="https://github.com/urbit/urbit/issues/4257">issue</a> may give more insight.</p>
+                            <p>While Port itself can run on Apple M1 architecture, Urbit itself cannot yet. We're actively working on a solution, which is being tracked in this <a href="https://github.com/urbit/urbit/issues/4257">issue</a>.</p>
                             <p className="flex flex-end">
                                 <Button onClick={() => send('quit')}>
                                     <Close className="w-7 h-7" primary="fill-current" /> Quit


### PR DESCRIPTION
This fixes an issue that was preventing the M1 warning from popping up. It also cleans up the copy and allows users to proceed if they want to use for remote ship browsing.