### PR TITLE
Persistance for Landscape sessions

### DIFF
--- a/src/background/db/index.ts
+++ b/src/background/db/index.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { AsyncNedb } from 'nedb-async'
 import { remote } from 'electron';
-import { BootMessage, Pier } from '../services/pier-service';
+import { BootMessage, LandscapeSession, Pier } from '../services/pier-service';
 const userData = remote.app.getPath('userData');
 
 console.log('db location:', userData)
@@ -15,10 +15,12 @@ export interface DB {
     settings: AsyncNedb<SettingsDocument>;
     piers: AsyncNedb<Pier>;
     messageLog: AsyncNedb<BootMessage>;
+    sessions: AsyncNedb<LandscapeSession>;
 }
 
 export default {
     settings: new AsyncNedb<SettingsDocument>({ filename: path.join(userData, 'db', 'settings.db'), autoload: true }),
     piers: new AsyncNedb<Pier>({ filename: path.join(userData, 'db', 'piers.db'), autoload: true }),
-    messageLog: new AsyncNedb<BootMessage>({ filename: path.join(userData, 'db', 'message-log.db'), autoload: true })
+    messageLog: new AsyncNedb<BootMessage>({ filename: path.join(userData, 'db', 'message-log.db'), autoload: true }),
+    sessions: new AsyncNedb<BootMessage>({ filename: path.join(userData, 'db', 'sessions.db'), autoload: true })
 }

--- a/src/background/services/os-service.ts
+++ b/src/background/services/os-service.ts
@@ -1,5 +1,6 @@
 import { HandlerEntry } from '../server/ipc';
 import { ipcRenderer as ipc} from 'electron'
+import { SessionData } from './pier-service';
 
 export interface OSHandlers {
     'quit': OSService['quit'];
@@ -90,8 +91,8 @@ export class OSService {
         await ipc.invoke('update-view-bounds', data);
     }
 
-    async removeView(url: string): Promise<void> {
-        await ipc.invoke('remove-view', url);
+    async removeView(url: string): Promise<SessionData> {
+        return await ipc.invoke('remove-view', url);
     }
 
     async installUpdates(): Promise<void> {
@@ -101,11 +102,12 @@ export class OSService {
 
 export interface ViewData {
     url: string;
+    session?: SessionData;
     bounds: {
         x: number;
         y: number;
         width: number;
         height: number;
-    }
+    };
 }
 

--- a/src/renderer/ship/components/LandscapeWindow.tsx
+++ b/src/renderer/ship/components/LandscapeWindow.tsx
@@ -56,6 +56,7 @@ export const LandscapeWindow: React.FC<LandscapeWindowProps> = ({ pier, loading 
         const unlisten = history.listen(async () => {
             let session = await send('remove-view', url)
             send('upsert-session', {slug: pier.slug, data: session})
+            console.log('removing', url)
         });
 
         return () => unlisten && unlisten();

--- a/src/renderer/ship/components/LandscapeWindow.tsx
+++ b/src/renderer/ship/components/LandscapeWindow.tsx
@@ -34,8 +34,10 @@ export const LandscapeWindow: React.FC<LandscapeWindowProps> = ({ pier, loading 
     useEffect(() => {
         async function createView() {
             try {
+                let session = await send('get-session', pier.slug)
                 await send('create-view', {
                     url,
+                    session: session?.data,
                     bounds: getBounds(landscapeRef.current)
                 })
                 setStatus('loaded')
@@ -51,9 +53,9 @@ export const LandscapeWindow: React.FC<LandscapeWindowProps> = ({ pier, loading 
     }, [landscapeRef.current, url])
 
     useEffect(() => {
-        const unlisten = history.listen(() => {
-            send('remove-view', url)
-            console.log('removing', url)
+        const unlisten = history.listen(async () => {
+            let session = await send('remove-view', url)
+            send('upsert-session', {slug: pier.slug, data: session})
         });
 
         return () => unlisten && unlisten();


### PR DESCRIPTION
Landscape "sessions" use `localStorage` to maintain group configuration settings (including those relevant for #112) rather than storing that data directly in the urbit itself. This pull request adds basic support for storing that configuration info and loading it back when reopening Port.

This implementation creates a new database entity for `LandscapeSession`s, but uses the `pier-service` for access. I didn't want to tack the sessions onto the pier object since they can get fairly large and piers are passed around frequently in Port. At the same time, creating a separate service to handle them felt like overkill since all we need is basic reading/writing.

The code here is working, but a few concerns need to be addressed before this would be ready to merge:

## Landscape state synchronization
The current functionality is fairly blunt in that it just saves/loads everything in `localStorage`. While I think this is fine for the group configuration keys we're targeting, I don't know enough about how Landscape manages state to know whether or not this may introduce issues with respect to other stored properties (e.g. `LandscapeLaunchState`, `LandscapeMetadataState`, etc.).

Additionally, we can't configure `localStorage` until after the `BrowserView` loads the pier URL. I'm unsure as to whether this will create any overwrites or race conditions with respect to Landscape's startup logic.

@arthyn do you know more about this? We could potentially target the group properties exclusively, but partial session persistence may be counterintuitive from a user perspective.

## Syncing sessions on exit
Right now saving the session is only triggered when you navigate away from Landscape (either by clicking home or changing the URL directly in the toolbar). We need a way to save these when the user exits landscape before navigating away. I wanted to check with you before coding something up.

To handle this I was thinking we could either __1.__ implement a basic polling solution where the `LandscapeWindow` component would save the session every so often or __2.__ have the main process watch for exit and save the sessions before closing. 

I think there's a tradeoff here between correctness and complexity. Polling would probably be fine in most situations, but could result in saving a stale session. Whereas watching for exit would involve violating the separation of concerns currently in place where `pier-service` and `os-service` operations don't really interact with each other (that happens a layer up in the render process).

Let me know if you think of a more elegant way to solve this though.

closes #112 