### PR TITLE
Display Ship Name in Window Titles

### DIFF
--- a/src/background/db/index.ts
+++ b/src/background/db/index.ts
@@ -9,7 +9,8 @@ console.log('db location:', userData)
 export type Settings =
     | 'seen-grid-update-modal'
     | 'global-leap'
-    | 'protocol-handling';
+    | 'protocol-handling'
+    | 'ship-name-in-title';
 
 export interface SettingsDocument {
     name: Settings;

--- a/src/background/services/settings-service.ts
+++ b/src/background/services/settings-service.ts
@@ -12,7 +12,8 @@ export interface SettingsHandlers {
 const defaultSettings: SettingsDocument[] = [
   { name: 'seen-grid-update-modal', value: 'false' },
   { name: 'global-leap', value: 'true' },
-  { name: 'protocol-handling', value: 'true' }
+  { name: 'protocol-handling', value: 'true' },
+  { name: 'ship-name-in-title', value: 'false'}
 ]
 
 export class SettingsService {

--- a/src/main/helpers.ts
+++ b/src/main/helpers.ts
@@ -35,64 +35,15 @@ export function showWindow(window: BrowserWindow): void {
   });
 }
 
-export function linkIsInternal(
-  currentUrl: string,
-  newUrl: string,
-  internalUrlRegex?: string | RegExp,
-): boolean {
-  if (newUrl === 'about:blank') {
-    return true;
-  }
-
-  if (internalUrlRegex) {
-    const regex = RegExp(internalUrlRegex);
-    return regex.test(newUrl);
-  }
-
-  if (newUrl.startsWith(URBIT_PROTOCOL)) {
-    return true;
-  } 
-
-  try {
-    // Consider as "same domain-ish", without TLD/SLD list:
-    // 1. app.foo.com and foo.com
-    // 2. www.foo.com and foo.com
-    // 3. www.foo.com and app.foo.com
-    const currentDomain = new URL(currentUrl).hostname.replace(/^www\./, '');
-    const newDomain = new URL(newUrl).hostname.replace(/^www./, '');
-    const [longerDomain, shorterDomain] =
-      currentDomain.length > newDomain.length
-        ? [currentDomain, newDomain]
-        : [newDomain, currentDomain];
-    return longerDomain.endsWith(shorterDomain);
-  } catch (err) {
-    console.warn(
-      'Failed to parse domains as determining if link is internal. From:',
-      currentUrl,
-      'To:',
-      newUrl,
-      err,
-    );
-    return false;
-  }
-}
-
 export function onNewWindowHelper(
   urlToGo: string,
-  disposition: string,
   targetUrl: string,
   preventDefault,
-  openExternal,
   createAboutBlankWindow,
   createNewWindow,
-  blockExternal: boolean,
-  onBlockedExternalUrl: (url: string) => void,
   mainWindow: BrowserWindow
 ): void {
-  if (!linkIsInternal(targetUrl, urlToGo) && blockExternal) {
-    preventDefault();
-    onBlockedExternalUrl(urlToGo);
-  } else if (urlToGo === 'about:blank') {
+  if (urlToGo === 'about:blank') {
     const newWindow = createAboutBlankWindow();
     preventDefault(newWindow);
   } else {

--- a/src/main/helpers.ts
+++ b/src/main/helpers.ts
@@ -76,10 +76,9 @@ export function onNavigation({ urlTarget, currentUrl, preventDefault, createNewW
   }
 
   const sameHost = targetUrl.hostname === url.hostname;
-  const sameApp = sameHost && targetUrl.pathname.split('/')[1] === url.pathname.split('/')[1];
   isDev && console.log('navigating', url.pathname, targetUrl.pathname)
 
-  if ((!sameHost || sameApp) && !isProtocolLink) {
+  if ((!sameHost) && !isProtocolLink) {
       return;
   }
 
@@ -101,23 +100,19 @@ export function onNavigation({ urlTarget, currentUrl, preventDefault, createNewW
   }
 
   const targetWindow = BrowserWindow.getAllWindows().find(b => {
-    const portPathSegment = targetUrl.port ? `:${targetUrl.port}` : ''
     const path = b.webContents.getURL()
-      .replace(`${targetUrl.protocol}//${targetUrl.hostname}${portPathSegment}`, '');
+      .replace(`${targetUrl.protocol}//${targetUrl.host}`, '');
     return path.startsWith(targetUrl.pathname);
   })
 
   if (targetWindow) {
-    const targetWindowPort = (new URL(targetWindow.webContents.getURL())).port;
-    if (!sameApp && targetWindowPort === targetUrl.port) {
-      preventDefault();
-      targetWindow.focus();
+    preventDefault();
+    targetWindow.focus();
 
-      if (targetUrl.searchParams.has('grid-note') || targetUrl.searchParams.has('grid-link')) {
-        targetWindow.webContents.loadURL(targetUrl.toString());
-      }
-      return;
+    if (targetUrl.searchParams.has('grid-note') || targetUrl.searchParams.has('grid-link')) {
+      targetWindow.webContents.loadURL(targetUrl.toString());
     }
+    return;
   }
 
   if (createNewWindow) {

--- a/src/main/main-window.ts
+++ b/src/main/main-window.ts
@@ -153,15 +153,6 @@ export function createMainWindow(
   const getCurrentUrl = (): string =>
     withFocusedView((contents) => contents.getURL());
 
-  const onBlockedExternalUrl = (url: string) => {
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    dialog.showMessageBox(mainWindow, {
-      message: `Cannot navigate to external URL: ${url}`,
-      type: 'error',
-      title: 'Navigation blocked',
-    });
-  };
-
   const onWillNavigate = (event: Event, webContents: WebContents, urlTarget: string): void => {
     isDev && console.log('will-navigate', urlTarget)
     onNavigation({
@@ -242,14 +233,10 @@ export function createMainWindow(
     };
     onNewWindowHelper(
       urlToGo,
-      disposition,
       targetUrl,
       preventDefault,
-      shell.openExternal.bind(this),
       createAboutBlankWindow,
       createNewWindow,
-      false,
-      onBlockedExternalUrl,
       mainWindow
     );
   };

--- a/src/main/main-window.ts
+++ b/src/main/main-window.ts
@@ -179,20 +179,20 @@ export function createMainWindow(
 
   const configureWindowTitle = (window: BrowserWindow) => {
     mainWindow.webContents.send('current-ship')
-    ipcMain.on('current-ship', (_, { displayShipName, shipName }: { displayShipName: boolean, shipName: string}) => {
+    ipcMain.on('current-ship', (_, { shouldDisplay, displayName }: { shouldDisplay: boolean, displayName: string}) => {
       ipcMain.removeAllListeners('current-ship')
 
-      if (!displayShipName || !shipName) {
+      if (!shouldDisplay || !displayName) {
         return
       }
 
-      const titlePrefix = ` (${shipName})`
+      const titlePrefix = ` (${displayName})`
       window.setTitle(`${window.webContents.getTitle()}${titlePrefix}`)
 
       // webContents cannot detect in-page navigations (which may change the title), so we inject that behavior
       const setTitleScript = `
         new MutationObserver( () => {
-            if (!document.title.includes("${shipName}")) {
+            if (!document.title.includes("${displayName}")) {
               document.title = document.title + "${titlePrefix}"
             }
         }).observe(

--- a/src/main/main-window.ts
+++ b/src/main/main-window.ts
@@ -182,7 +182,7 @@ export function createMainWindow(
     ipcMain.on('current-ship', (_, { displayShipName, shipName }: { displayShipName: boolean, shipName: string}) => {
       ipcMain.removeAllListeners('current-ship')
 
-      if (!displayShipName) {
+      if (!displayShipName || !shipName) {
         return
       }
 

--- a/src/main/main-window.ts
+++ b/src/main/main-window.ts
@@ -188,17 +188,20 @@ export function createMainWindow(
 
   const configureWindowTitle = (window: BrowserWindow) => {
     mainWindow.webContents.send('current-ship')
-    ipcMain.on('current-ship', (_, rawShipName: string) => {
+    ipcMain.on('current-ship', (_, { displayShipName, shipName }: { displayShipName: boolean, shipName: string}) => {
       ipcMain.removeAllListeners('current-ship')
 
-      const formattedShipName = rawShipName.trim()
-      const titlePrefix = ` (${formattedShipName})`
+      if (!displayShipName) {
+        return
+      }
+
+      const titlePrefix = ` (${shipName})`
       window.setTitle(`${window.webContents.getTitle()}${titlePrefix}`)
 
       // webContents cannot detect in-page navigations (which may change the title), so we inject that behavior
       const setTitleScript = `
         new MutationObserver( () => {
-            if (!document.title.includes("${formattedShipName}")) {
+            if (!document.title.includes("${shipName}")) {
               document.title = document.title + "${titlePrefix}"
             }
         }).observe(

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -53,6 +53,7 @@ export const useStore = create<PortStore>(() => ({
         'seen-grid-update-modal': 'true',
         'global-leap': 'true',
         'protocol-handling': 'true',
+        'ship-name-in-title': 'false',
     },
     updateStatus: 'initial',
     zoomLevels: {

--- a/src/renderer/pages/Settings.tsx
+++ b/src/renderer/pages/Settings.tsx
@@ -13,6 +13,7 @@ export const Settings = () => {
   const settings = useStore(s => s.settings);
   const leapGlobally = settings['global-leap'] === 'true';
   const protocolHandling = settings['protocol-handling'] === 'true';
+  const shipNameInTitle = settings['ship-name-in-title'] === 'true';
   const { mutate: setSetting } = useMutation(({ setting, on }: { setting: SettingsType, on: boolean }) => {
       return send('set-setting', setting, on.toString())
     }, {
@@ -48,7 +49,7 @@ export const Settings = () => {
           </div>
         </div>
         <h2 className="mb-3 text-black dark:text-white">Leap</h2>
-        <div className="flex items-center space-x-4">
+        <div className="flex items-center mb-6 space-x-4">
           <Toggle 
             pressed={protocolHandling}
             onPressedChange={(on) => setSetting({ setting: 'protocol-handling', on })}
@@ -58,6 +59,19 @@ export const Settings = () => {
           <div className="w-96">
             {protocolHandling && <p>Allow Port to handle any and all <strong className='font-mono'>web+urbitgraph</strong> links</p>}
             {!protocolHandling && <p><strong className='font-mono'>web+urbitgraph</strong> link handling disabled</p>}
+          </div>
+        </div>
+        <h2 className="mb-3 text-black dark:text-white">Show Ship</h2>
+        <div className="flex items-center space-x-4">
+          <Toggle
+            pressed={shipNameInTitle}
+            onPressedChange={(on) => setSetting({ setting: 'ship-name-in-title', on })}
+            className="text-blue-500"
+            toggleClass="w-9 h-6"
+          />
+          <div className="w-96">
+            {shipNameInTitle && <p>Ship name will be displayed in the title of app windows</p>}
+            {!shipNameInTitle && <p>Ship name will not be displayed in the title of app windows</p>}
           </div>
         </div>
       </section>

--- a/src/renderer/ship/Launch.tsx
+++ b/src/renderer/ship/Launch.tsx
@@ -5,6 +5,7 @@ import { Link, useParams } from 'react-router-dom'
 import { Pier } from '../../background/services/pier-service'
 import { send } from '../client/ipc'
 import { getCometShortName } from '../shared/urbit-utils'
+import { useStore } from '../App';
 import { LeftArrow } from '../icons/LeftArrow'
 import { pierKey } from '../query-keys'
 import { Button } from '../shared/Button'
@@ -55,6 +56,7 @@ const LaunchFooter: React.FC<{ pier: Pier }> = ({ pier }) => {
 export const Launch = () => {
     const { slug } = useParams<{ slug: string }>()
     const [pier, setPier] = useState<Pier>();
+    const settings = useStore(s => s.settings);
     const { data: initialPier } = useQuery(pierKey(slug), () => send('get-pier', slug))
     const pierLoaded = initialPier?.slug;
     const { mutate, isIdle, isLoading } = useMutation(() => send('resume-pier', initialPier), 
@@ -73,7 +75,10 @@ export const Launch = () => {
 
     useEffect(() => {
         const handle =  () => {
-            ipcRenderer.send('current-ship', getCometShortName(pier.shipName))
+            ipcRenderer.send('current-ship', {
+                displayShipName: settings['ship-name-in-title'] === 'true',
+                shipName: getCometShortName(pier.shipName).trim()
+            })
         }
 
         ipcRenderer.on('current-ship', handle)

--- a/src/renderer/ship/Launch.tsx
+++ b/src/renderer/ship/Launch.tsx
@@ -76,8 +76,8 @@ export const Launch = () => {
     useEffect(() => {
         const handle =  () => {
             ipcRenderer.send('current-ship', {
-                displayShipName: settings['ship-name-in-title'] === 'true',
-                shipName: getCometShortName(pier.shipName).trim()
+                shouldDisplay: settings['ship-name-in-title'] === 'true',
+                displayName: pier.shipName ? getCometShortName(pier.shipName).trim() : pier.name.trim(),
             })
         }
 

--- a/src/renderer/ship/Launch.tsx
+++ b/src/renderer/ship/Launch.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useState } from 'react'
+import { ipcRenderer } from 'electron'
 import { useMutation, useQuery, useQueryClient } from 'react-query'
 import { Link, useParams } from 'react-router-dom'
 import { Pier } from '../../background/services/pier-service'
 import { send } from '../client/ipc'
+import { getCometShortName } from '../shared/urbit-utils'
 import { LeftArrow } from '../icons/LeftArrow'
 import { pierKey } from '../query-keys'
 import { Button } from '../shared/Button'
@@ -68,6 +70,18 @@ export const Launch = () => {
             mutate()
         }
     }, [pierLoaded])
+
+    useEffect(() => {
+        const handle =  () => {
+            ipcRenderer.send('current-ship', getCometShortName(pier.shipName))
+        }
+
+        ipcRenderer.on('current-ship', handle)
+
+        return () => {
+            ipcRenderer.removeListener('current-ship', handle)
+        }
+    }, [pier]);
 
     return (
         <Layout 


### PR DESCRIPTION
closes https://github.com/urbit/port/issues/149

Adds support for optionally showing the name of the ship in spawned window titles. 

While working on this, I discovered a portion of the code for spawning new windows was not being executed due to (what I presume is) a bug, more details below.

## Design Decisions
- Main process uses Electron ipc to get the ship name from Renderer rather than asking Background for it directly
- After playing around with the styling a bit, I thought the `Groups (~latter-bolden)` formatting looked best in app
- For users who primarily use a single ship, this feature isn't really necessary and detracts from the visual experience (imo). As such, I made it an option that is off by default

## Same App Detection Bug
When I went to modify the title configuration in `main-window`, I found out we weren't manually handling window spawns most of the time. A path comparison in `onNavigation` was being miscalculated (`sameapp`) which led to the function always bailing out to default nav behavior on the first conditional. This also meant nav handlers weren't being initialized for subsequent changes within the created window.

After fixing the problem, the implied functionality wasn't operating as expected (external links opened in browser, only able to open one window per app across all ships, etc.). I tried to interpret the intentions of the code and tweaked it accordingly. 

Compared to current Port functionality, the only significant user facing difference is that opening apps repeatedly focuses on the existing window rather than spawning new ones. Opening the same app from another ship works as expected though.