### PR TITLE
Ames Port Configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "typescript": "^4.0.2"
   },
   "dependencies": {
+    "@radix-ui/react-collapsible": "^0.1.6",
     "@radix-ui/react-dialog": "^0.0.16",
     "@radix-ui/react-dropdown-menu": "^0.0.18",
     "@radix-ui/react-popover": "^0.0.16",

--- a/src/background/services/pier-service.ts
+++ b/src/background/services/pier-service.ts
@@ -494,6 +494,11 @@ export class PierService {
             args.push('-t')
         }
 
+        if (pier.amesPort) {
+            args.push('-p')
+            args.push(pier.amesPort)
+        }
+
         if (pier.type === 'comet' && unbooted) {
             args.push('-c')
         } else if (['star', 'planet', 'moon'].includes(pier.type) && unbooted) {
@@ -652,12 +657,13 @@ export interface Pier {
     keyFile?: string;
     webPort?: number;
     loopbackPort?: number;
+    amesPort?: number;
     directoryAsPierPath?: boolean;
     bootProcessId?: number;
     bootProcessDisconnected?: boolean;
 }
 
-export type AddPier = Pick<Pier, 'name' | 'type' | 'shipName' | 'keyFile'> & {
+export type AddPier = Pick<Pier, 'name' | 'type' | 'shipName' | 'amesPort' | 'keyFile'> & {
     status?: ShipStatus;
     directory?: string;
     directoryAsPierPath?: boolean;

--- a/src/renderer/details/components/AdvancedOptions.tsx
+++ b/src/renderer/details/components/AdvancedOptions.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import * as Collapsible from '@radix-ui/react-collapsible'
+import { UseFormMethods } from 'react-hook-form/dist/types'
+import { AddPier } from '../../../background/services/pier-service'
+import {ChevronDown} from '../../icons/ChevronDown'
+import {PortField} from './PortField'
+
+type AdvancedOptionsProps = {
+  className?: string,
+  form: UseFormMethods<AddPier>,
+  children?: React.ReactNode
+}
+
+export const AdvancedOptions: React.FC<AdvancedOptionsProps> = ({ form }) => {
+  const [open, setOpen] = React.useState(false)
+
+  return (
+    <div className="relative">
+      <Collapsible.Root open={open} onOpenChange={setOpen} className="absolute">
+        <Collapsible.Trigger className="button border-none focus:outline-none cursor-pointer text-gray-400 dark:text-gray-500">
+          Advanced Options <ChevronDown className="ml-1 w-5 h-5" primary="fill-current" />
+        </Collapsible.Trigger>
+        <Collapsible.Content className="pt-5">
+          <label htmlFor="port">Ames Port</label>
+          <PortField form={form} />
+        </Collapsible.Content>
+      </Collapsible.Root>
+    </div>
+  )
+}

--- a/src/renderer/details/components/PortField.tsx
+++ b/src/renderer/details/components/PortField.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { UseFormMethods, Validate } from 'react-hook-form/dist/types'
+import { AddPier } from '../../../background/services/pier-service'
+
+interface ShipNameFieldProps {
+    form: UseFormMethods<AddPier>;
+    placeholder?: string;
+    validator?: Validate;
+}
+
+export const PortField: React.FC<ShipNameFieldProps> = ({ form, validator, placeholder = 'default' }) => {
+    return (
+        <>
+            <input 
+                id="amesPort" 
+                name="amesPort" 
+                type="number"
+                ref={form.register({ 
+                    validate: validator,
+                    min: 1024,
+                    max: 65535
+                })}
+                className="input flex w-full mt-2" 
+                placeholder={placeholder}
+                aria-invalid={!!form.errors.shipName}
+            />
+            <span className={`inline-block h-8.5 mt-2 text-xs text-red-600 ${form.errors.amesPort ? 'visible' : 'invisible'}`} role="alert">
+              Invalid port. Must be a number between 1024-65535
+            </span>
+        </>
+    )
+}

--- a/src/renderer/details/pages/CometDetails.tsx
+++ b/src/renderer/details/pages/CometDetails.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { send } from '../../client/ipc'
 import { DetailsContainer } from '../components/DetailsContainer'
 import { NameField } from '../components/NameField'
+import { AdvancedOptions } from '../components/AdvancedOptions'
 import { useAddPier } from '../useAddPier'
 
 export const CometDetails: React.FC = () => {
@@ -23,6 +24,7 @@ export const CometDetails: React.FC = () => {
                 <label htmlFor="name">Name <span className="text-gray-300 dark:text-gray-700">(local only)</span></label>
                 <NameField form={form} />
             </div>
+            <AdvancedOptions form={form} />
         </DetailsContainer>
     )
 }

--- a/src/renderer/details/pages/ExistingShipDetails.tsx
+++ b/src/renderer/details/pages/ExistingShipDetails.tsx
@@ -5,8 +5,6 @@ import { send } from '../../client/ipc'
 import { DetailsContainer } from '../components/DetailsContainer'
 import { NameField } from '../components/NameField'
 import { useAddPier } from '../useAddPier'
-import { Dropdown } from '../components/Dropdown'
-import { PortField } from '../components/PortField'
 import { AdvancedOptions } from '../components/AdvancedOptions'
 
 export const ExistingShipDetails = () => {

--- a/src/renderer/details/pages/ExistingShipDetails.tsx
+++ b/src/renderer/details/pages/ExistingShipDetails.tsx
@@ -5,6 +5,9 @@ import { send } from '../../client/ipc'
 import { DetailsContainer } from '../components/DetailsContainer'
 import { NameField } from '../components/NameField'
 import { useAddPier } from '../useAddPier'
+import { Dropdown } from '../components/Dropdown'
+import { PortField } from '../components/PortField'
+import { AdvancedOptions } from '../components/AdvancedOptions'
 
 export const ExistingShipDetails = () => {
     const {
@@ -73,6 +76,9 @@ export const ExistingShipDetails = () => {
             <div className="flex items-center text-gray-500 dark:text-gray-400">
                 <input id="keep-in-place" type="checkbox" name="shipStays" ref={form.register} className="mr-2"/>
                 <label htmlFor="keep-in-place">Keep pier in current directory</label>
+            </div>
+            <div className="mt-6">
+                <AdvancedOptions form={form}/>
             </div>
         </DetailsContainer>
     )

--- a/src/renderer/details/pages/MoonDetails.tsx
+++ b/src/renderer/details/pages/MoonDetails.tsx
@@ -9,6 +9,7 @@ import { DetailsContainer } from '../components/DetailsContainer'
 import { NameField } from '../components/NameField'
 import { ShipNameField } from '../components/ShipNameField'
 import { KeyfileField } from '../components/KeyfileField'
+import { AdvancedOptions } from '../components/AdvancedOptions'
 
 export const MoonDetails: React.FC = () => {
     const [tab, setTab] = useState('manual')
@@ -83,6 +84,9 @@ export const MoonDetails: React.FC = () => {
                     <div>
                         <label htmlFor="directory">Key File</label>
                         <KeyfileField form={form} rules={{ validate: { tabOff: manualValidate }}} />
+                    </div>
+                    <div>
+                        <AdvancedOptions form={form}/>
                     </div>
                 </Tabs.Panel>
             </Tabs.Root>

--- a/src/renderer/details/pages/PlanetDetails.tsx
+++ b/src/renderer/details/pages/PlanetDetails.tsx
@@ -4,6 +4,7 @@ import { DetailsContainer } from '../components/DetailsContainer'
 import { KeyfileField } from '../components/KeyfileField'
 import { NameField } from '../components/NameField'
 import { ShipNameField } from '../components/ShipNameField'
+import { AdvancedOptions } from '../components/AdvancedOptions'
 import { useAddPier } from '../useAddPier'
 
 export const PlanetDetails: React.FC = () => {
@@ -31,6 +32,9 @@ export const PlanetDetails: React.FC = () => {
             <div>
                 <label htmlFor="directory">Key File</label>
                 <KeyfileField form={form} rules={{ required: true }} />
+            </div>
+            <div className="mt-2">
+                <AdvancedOptions form={form}/>
             </div>
         </DetailsContainer>
     )

--- a/src/renderer/details/pages/Star.tsx
+++ b/src/renderer/details/pages/Star.tsx
@@ -4,6 +4,7 @@ import { DetailsContainer } from '../components/DetailsContainer'
 import { KeyfileField } from '../components/KeyfileField'
 import { NameField } from '../components/NameField'
 import { ShipNameField } from '../components/ShipNameField'
+import { AdvancedOptions } from '../components/AdvancedOptions'
 import { useAddPier } from '../useAddPier'
 
 export const Star: React.FC = () => {
@@ -31,6 +32,9 @@ export const Star: React.FC = () => {
             <div>
                 <label htmlFor="directory">Key File</label>
                 <KeyfileField form={form} rules={{ required: true }} />
+            </div>
+            <div>
+                <AdvancedOptions form={form}/>
             </div>
         </DetailsContainer>
     )

--- a/src/renderer/shared/Toggle.tsx
+++ b/src/renderer/shared/Toggle.tsx
@@ -1,59 +1,51 @@
 import classNames from 'classnames';
 import React, { useState } from 'react';
 import * as RadixToggle from '@radix-ui/react-toggle';
-import type * as Polymorphic from '@radix-ui/react-polymorphic';
 
-type ToggleComponent = Polymorphic.ForwardRefComponent<
-  Polymorphic.IntrinsicElement<typeof RadixToggle.Root>,
-  Polymorphic.OwnProps<typeof RadixToggle.Root> & {
+type ToggleProps = {
     toggleClass?: string;
     knobClass?: string;
-  }
->;
+} & React.PropsWithChildren<RadixToggle.ToggleOwnProps> & React.HTMLProps<HTMLButtonElement>
 
-export const Toggle = React.forwardRef(
-  (
-    { defaultPressed, pressed, onPressedChange, disabled, className, toggleClass },
-    ref
-  ) => {
-    const [on, setOn] = useState(defaultPressed);
-    const isControlled = !!onPressedChange;
-    const proxyPressed = isControlled ? pressed : on;
-    const proxyOnPressedChange = isControlled ? onPressedChange : setOn;
-    const knobPosition = proxyPressed ? 18 : 2;
+export const Toggle: React.FC<ToggleProps> = (
+  { defaultPressed, pressed, onPressedChange, disabled, className, toggleClass }
+) => {
+  const [on, setOn] = useState(defaultPressed);
+  const isControlled = !!onPressedChange;
+  const proxyPressed = isControlled ? pressed : on;
+  const proxyOnPressedChange = isControlled ? onPressedChange : setOn;
+  const knobPosition = proxyPressed ? 18 : 2;
 
-    return (
-      <RadixToggle.Root
-        className={classNames('default-ring rounded-full', className)}
-        pressed={proxyPressed}
-        onPressedChange={proxyOnPressedChange}
-        disabled={disabled}
-        ref={ref}
+  return (
+    <RadixToggle.Root
+      className={classNames('default-ring rounded-full', className)}
+      pressed={proxyPressed}
+      onPressedChange={proxyOnPressedChange}
+      disabled={disabled}
+    >
+      <svg
+        className={classNames(toggleClass)}
+        viewBox="0 0 48 32"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <svg
-          className={classNames(toggleClass)}
-          viewBox="0 0 48 32"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            className={classNames(
-              'fill-current',
-              disabled && proxyPressed && 'text-gray-700 dark:text-gray-500',
-              !proxyPressed && 'text-gray-200 dark:text-gray-700'
-            )}
-            d="M0 16C0 7.16344 7.16344 0 16 0H32C40.8366 0 48 7.16344 48 16C48 24.8366 40.8366 32 32 32H16C7.16344 32 0 24.8366 0 16Z"
-          />
-          <rect
-            className={classNames('fill-current text-white', disabled && 'opacity-60')}
-            x={knobPosition}
-            y="2"
-            width="28"
-            height="28"
-            rx="14"
-          />
-        </svg>
-      </RadixToggle.Root>
-    );
-  }
-) as ToggleComponent;
+        <path
+          className={classNames(
+            'fill-current',
+            disabled && proxyPressed && 'text-gray-700 dark:text-gray-500',
+            !proxyPressed && 'text-gray-200 dark:text-gray-700'
+          )}
+          d="M0 16C0 7.16344 7.16344 0 16 0H32C40.8366 0 48 7.16344 48 16C48 24.8366 40.8366 32 32 32H16C7.16344 32 0 24.8366 0 16Z"
+        />
+        <rect
+          className={classNames('fill-current text-white', disabled && 'opacity-60')}
+          x={knobPosition}
+          y="2"
+          width="28"
+          height="28"
+          rx="14"
+        />
+      </svg>
+    </RadixToggle.Root>
+  );
+};

--- a/src/renderer/styles/base.css
+++ b/src/renderer/styles/base.css
@@ -26,3 +26,8 @@ a:not([class]) {
 *::-webkit-resizer {
     @apply hidden;
 }
+
+*::-webkit-outer-spin-button,
+*::-webkit-inner-spin-button {
+    @apply hidden;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,9 +11,6 @@
     "outDir": "dist",
     "moduleResolution": "node",
     "resolveJsonModule": true,
-    "paths": {
-      "*": ["node_modules/*"]
-    },
     "jsx": "react"
   },
   "include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -621,6 +621,13 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@radix-ui/primitive@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-0.1.0.tgz#6206b97d379994f0d1929809db035733b337e543"
+  integrity sha512-tqxZKybwN5Fa3VzZry4G6mXAAb9aAqKmPtnVbZpL0vsBwvOHTBwsjHVPXylocYLwEtBY9SCe665bYnNB515uoA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
 "@radix-ui/react-arrow@0.0.12":
   version "0.0.12"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-0.0.12.tgz#1130683e39e136f97fa4b05be1cebdb92d993ab0"
@@ -629,6 +636,21 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-polymorphic" "0.0.11"
     "@radix-ui/react-primitive" "0.0.12"
+
+"@radix-ui/react-collapsible@^0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-collapsible/-/react-collapsible-0.1.6.tgz#3eeadac476761b3c9b8dd91e8a32eb1a547e5a06"
+  integrity sha512-Gkf8VuqMc6HTLzA2AxVYnyK6aMczVLpatCjdD9Lj4wlYLXCz9KtiqZYslLMeqnQFLwLyZS0WKX/pQ8j5fioIBw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "0.1.0"
+    "@radix-ui/react-compose-refs" "0.1.0"
+    "@radix-ui/react-context" "0.1.1"
+    "@radix-ui/react-id" "0.1.5"
+    "@radix-ui/react-presence" "0.1.2"
+    "@radix-ui/react-primitive" "0.1.4"
+    "@radix-ui/react-use-controllable-state" "0.1.0"
+    "@radix-ui/react-use-layout-effect" "0.1.0"
 
 "@radix-ui/react-collection@0.0.12":
   version "0.0.12"
@@ -646,10 +668,24 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@radix-ui/react-compose-refs@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-0.1.0.tgz#cff6e780a0f73778b976acff2c2a5b6551caab95"
+  integrity sha512-eyclbh+b77k+69Dk72q3694OHrn9B3QsoIRx7ywX341U9RK1ThgQjMFZoPtmZNQTksXHLNEiefR8hGVeFyInGg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
 "@radix-ui/react-context@0.0.5":
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-0.0.5.tgz#7c15f46795d7765dabfaf6f9c53791ad28c521c2"
   integrity sha512-bwrzAc0qc2EPepSTLBT4+93uCiI9wP78VSmPg2K+k71O/vpx7dPs0VqrewwCBNCHT54NIwaRr2hEsm2uqYi02A==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-context@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-0.1.1.tgz#06996829ea124d9a1bc1dbe3e51f33588fab0875"
+  integrity sha512-PkyVX1JsLBioeu0jB9WvRpDBBLtLZohVDT3BB5CTSJqActma8S8030P57mWZb4baZifMvN7KKWPAA40UmWKkQg==
   dependencies:
     "@babel/runtime" "^7.13.10"
 
@@ -720,6 +756,14 @@
   integrity sha512-PzmraF34fYggsYvTIZVJ5S68WMp3aKUN3HkSmGnz4zn9zpRjkAbbg7Xn3ueQI3FQsLWKgyUfnpsmWFDndpcqYg==
   dependencies:
     "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-id@0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-0.1.5.tgz#010d311bedd5a2884c1e9bb6aaaa4e6cc1d1d3b8"
+  integrity sha512-IPc4H/63bes0IZ1GJJozSEkSWcDyhNGtKFWUpJ+XtaLyQ1X3x7Mf6fWwWhDcpqlYEP+5WtAvfqcyEsyjP+ZhBQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-layout-effect" "0.1.0"
 
 "@radix-ui/react-menu@0.0.17":
   version "0.0.17"
@@ -814,6 +858,15 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-compose-refs" "0.0.5"
 
+"@radix-ui/react-presence@0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-0.1.2.tgz#9f11cce3df73cf65bc348e8b76d891f0d54c1fe3"
+  integrity sha512-3BRlFZraooIUfRlyN+b/Xs5hq1lanOOo/+3h6Pwu2GMFjkGKKa4Rd51fcqGqnVlbr3jYg+WLuGyAV4KlgqwrQw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "0.1.0"
+    "@radix-ui/react-use-layout-effect" "0.1.0"
+
 "@radix-ui/react-primitive@0.0.12":
   version "0.0.12"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-0.0.12.tgz#b4bad44d95c415cf16aa3ac6cf83de7813d6f27f"
@@ -829,6 +882,14 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-polymorphic" "0.0.13"
+
+"@radix-ui/react-primitive@0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-0.1.4.tgz#6c233cf08b0cb87fecd107e9efecb3f21861edc1"
+  integrity sha512-6gSl2IidySupIMJFjYnDIkIWRyQdbu/AHK7rbICPani+LW4b0XdxBXc46og/iZvuwW8pjCS8I2SadIerv84xYA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-slot" "0.1.2"
 
 "@radix-ui/react-roving-focus@0.0.12":
   version "0.0.12"
@@ -854,6 +915,14 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/primitive" "0.0.5"
     "@radix-ui/react-compose-refs" "0.0.5"
+
+"@radix-ui/react-slot@0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-0.1.2.tgz#e6f7ad9caa8ce81cc8d532c854c56f9b8b6307c8"
+  integrity sha512-ADkqfL+agEzEguU3yS26jfB50hRrwf7U4VTwAOZEmi/g+ITcBWe12yM46ueS/UCIMI9Py+gFUaAdxgxafFvY2Q==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "0.1.0"
 
 "@radix-ui/react-tabs@^0.0.12":
   version "0.0.12"
@@ -919,6 +988,13 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@radix-ui/react-use-callback-ref@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz#934b6e123330f5b3a6b116460e6662cbc663493f"
+  integrity sha512-Va041McOFFl+aV+sejvl0BS2aeHx86ND9X/rVFmEFQKTXCp6xgUK0NGUAGcgBlIjnJSbMYPGEk1xKSSlVcN2Aw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
 "@radix-ui/react-use-controllable-state@0.0.6":
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-0.0.6.tgz#c4b16bc911a25889333388a684a04df937e5fec7"
@@ -926,6 +1002,14 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-use-callback-ref" "0.0.5"
+
+"@radix-ui/react-use-controllable-state@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-0.1.0.tgz#4fced164acfc69a4e34fb9d193afdab973a55de1"
+  integrity sha512-zv7CX/PgsRl46a52Tl45TwqwVJdmqnlQEQhaYMz/yBOD2sx2gCkCFSoF/z9mpnYWmS6DTLNTg5lIps3fV6EnXg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-callback-ref" "0.1.0"
 
 "@radix-ui/react-use-escape-keydown@0.0.6":
   version "0.0.6"
@@ -939,6 +1023,13 @@
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.0.5.tgz#cbbd059090edc765749da00d9f562a9abd43cbac"
   integrity sha512-bNPW2JNOr/p2hXr0hfKKqrEy5deNSRF17sw3l9Z7qlEnvIbBtQ7iwY/wrxIz5P7XFyYGoXodIUDH5G8PEucE3A==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-use-layout-effect@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.0.tgz#ebf71bd6d2825de8f1fbb984abf2293823f0f223"
+  integrity sha512-+wdeS51Y+E1q1Wmd+1xSSbesZkpVj4jsg0BojCbopWvgq5iBvixw5vgemscdh58ep98BwUbsFYnrywFhV9yrVg==
   dependencies:
     "@babel/runtime" "^7.13.10"
 


### PR DESCRIPTION
closes https://github.com/urbit/port/issues/128

Adds the ability to configure the ames port of a ship at first boot. 

My only concern is that new ship configuration pages are getting kind of long. Not sure what our responsive goals are, but @arthyn lemme know if it feels unacceptable and I can update it as needed.

## Design Decisions
- Feature seemed niche and might confuse non-technical users, so I hid it in a new "Advanced Options" component
- Noticed we were using Radix components elsewhere, so I pulled in a dependency for the collapsible. Should have a11y wins  compared to rolling my own