### PR TITLE
Key File Info and Warnings

### DIFF
--- a/src/main/context-menu.ts
+++ b/src/main/context-menu.ts
@@ -1,10 +1,11 @@
 import { shell } from 'electron';
+import isDev from 'electron-is-dev'
 import contextMenu from 'electron-context-menu';
 
 //Taken from https://github.com/nativefier/nativefier/blob/master/app/src/components/contextMenu.ts
 export function initContextMenu(createNewWindow, createNewTab, mainUrl, window?): void {
   const options: contextMenu.Options = {
-    showInspectElement: false,
+    showInspectElement: isDev,
     prepend: (actions, params) => {
       const items = [];
       const showOpenLink = !params.pageURL.startsWith(mainUrl)

--- a/src/renderer/details/components/KeyfileField.tsx
+++ b/src/renderer/details/components/KeyfileField.tsx
@@ -58,16 +58,16 @@ export const KeyfileField: React.FC<KeyfileFieldProps> = ({ form, rules, childre
                             </button>
                             <Dialog open={warningOpen} onOpenChange={setWarningOpen}>
                                 <DialogContent showCloseIcon onOpenAutoFocus={e => e.preventDefault()}>
-                                    <h2 className="font-semibold">Keyfile Warning</h2>
+                                    <h2 className="font-semibold">Key File Warning</h2>
                                     <p className="mt-4">
-                                        Starting a ship with it's keyfile should only be done once. Doing so repeatedly will
+                                        Starting a ship with it's key file should only be done once. Doing so repeatedly will
                                         break your ship and require a factory reset.
                                     </p>
                                     <p className="mt-4">
-                                        If your keyfile has already been used, export your pier folder and <Link to="/boot/existing">boot as an existing ship</Link> instead.
+                                        If your key file has already been used, export your pier folder and <Link to="/boot/existing">boot as an existing ship</Link> instead.
                                     </p>
                                     <div className="mt-8 flex justify-center">
-                                        <button className="button text-black bg-yellow-300 hover:bg-yellow-400 dark:bg-transparent dark:border-yellow-200 dark:text-yellow-200 dark:hover:bg-transparent dark:hover:border-yellow-400 dark:hover:text-yellow-400" onClick={async () => bypassWarning(onChange)}>Continue, this keyfile has not been used</button>
+                                        <button className="button text-black bg-yellow-300 hover:bg-yellow-400 dark:bg-transparent dark:border-yellow-200 dark:text-yellow-200 dark:hover:bg-transparent dark:hover:border-yellow-400 dark:hover:text-yellow-400" onClick={async () => bypassWarning(onChange)}>Continue, this key file has not been used</button>
                                     </div>
                                 </DialogContent>
                             </Dialog>

--- a/src/renderer/details/components/KeyfileField.tsx
+++ b/src/renderer/details/components/KeyfileField.tsx
@@ -67,7 +67,7 @@ export const KeyfileField: React.FC<KeyfileFieldProps> = ({ form, rules, childre
                                         If your keyfile has already been used, export your pier folder and <Link to="/boot/existing">boot as an existing ship</Link> instead.
                                     </p>
                                     <div className="mt-8 flex justify-center">
-                                        <button className="button border-yellow-200 text-yellow-200 hover:border-yellow-400 hover:text-yellow-400" onClick={async () => bypassWarning(onChange)}>Continue, this keyfile has not been used</button>
+                                        <button className="button text-black bg-yellow-300 hover:bg-yellow-400 dark:bg-transparent dark:border-yellow-200 dark:text-yellow-200 dark:hover:bg-transparent dark:hover:border-yellow-400 dark:hover:text-yellow-400" onClick={async () => bypassWarning(onChange)}>Continue, this keyfile has not been used</button>
                                     </div>
                                 </DialogContent>
                             </Dialog>

--- a/src/renderer/details/components/KeyfileField.tsx
+++ b/src/renderer/details/components/KeyfileField.tsx
@@ -2,9 +2,11 @@ import React from 'react'
 import { Controller } from 'react-hook-form'
 import { Link } from 'react-router-dom'
 import { UseControllerOptions, UseFormMethods, Validate, ValidateResult } from 'react-hook-form/dist/types'
+import * as Tooltip from '@radix-ui/react-tooltip'
 import { send } from '../../client/ipc'
 import { AddPier } from '../../../background/services/pier-service'
 import { Dialog, DialogContent } from '../../shared/Dialog'
+import { Question } from '../../icons/Question'
 
 interface KeyfileFieldProps {
     form: UseFormMethods<AddPier>
@@ -56,6 +58,15 @@ export const KeyfileField: React.FC<KeyfileFieldProps> = ({ form, rules, childre
                             <button type="button" className="input flex-none flex justify-center items-center hover:border-black focus:border-black dark:hover:border-white dark:focus:border-white default-ring rounded-l-none" onClick={() => setWarningOpen(true)}>
                                 Choose Key File
                             </button>
+                            <Tooltip.Root>
+                                <Tooltip.Trigger>
+                                    <Question className="h-5 w-5 ml-3 fill-current opacity-25 cursor-help" />
+                                </Tooltip.Trigger>
+                                <Tooltip.Content side="top" className="px-3 py-2 max-w-md text-sm bg-gray-100 dark:bg-gray-800 rounded">
+                                    You can find your key file inside your Passport. If you don't have a key file, you can download it from Bridge.
+                                    <Tooltip.Arrow className="fill-current text-gray-100 dark:text-gray-800"/>
+                                </Tooltip.Content>
+                            </Tooltip.Root>
                             <Dialog open={warningOpen} onOpenChange={setWarningOpen}>
                                 <DialogContent showCloseIcon onOpenAutoFocus={e => e.preventDefault()}>
                                     <h2 className="font-semibold">Key File Warning</h2>

--- a/src/renderer/details/components/KeyfileField.tsx
+++ b/src/renderer/details/components/KeyfileField.tsx
@@ -77,8 +77,9 @@ export const KeyfileField: React.FC<KeyfileFieldProps> = ({ form, rules, childre
                                     <p className="mt-4">
                                         If your key file has already been used, export your pier folder and <Link to="/boot/existing">boot as an existing ship</Link> instead.
                                     </p>
-                                    <div className="mt-8 flex justify-center">
+                                    <div className="mt-8 flex flex-col justify-between items-center">
                                         <button className="button text-black bg-yellow-300 hover:bg-yellow-400 dark:bg-transparent dark:border-yellow-200 dark:text-yellow-200 dark:hover:bg-transparent dark:hover:border-yellow-400 dark:hover:text-yellow-400" onClick={async () => bypassWarning(onChange)}>Continue, this key file has not been used</button>
+                                        <button className="mt-2 hover:opacity-60" onClick={() => setWarningOpen(false)}>cancel</button>
                                     </div>
                                 </DialogContent>
                             </Dialog>

--- a/src/renderer/details/components/KeyfileField.tsx
+++ b/src/renderer/details/components/KeyfileField.tsx
@@ -71,7 +71,7 @@ export const KeyfileField: React.FC<KeyfileFieldProps> = ({ form, rules, childre
                                 <DialogContent showCloseIcon onOpenAutoFocus={e => e.preventDefault()}>
                                     <h2 className="font-semibold">Key File Warning</h2>
                                     <p className="mt-4">
-                                        Starting a ship with it's key file should only be done once. Doing so repeatedly will
+                                        Starting a ship with its key file should only be done once. Doing so repeatedly will
                                         break your ship and require a factory reset.
                                     </p>
                                     <p className="mt-4">

--- a/src/renderer/details/components/KeyfileField.tsx
+++ b/src/renderer/details/components/KeyfileField.tsx
@@ -69,7 +69,7 @@ export const KeyfileField: React.FC<KeyfileFieldProps> = ({ form, rules, childre
                             </Tooltip.Root>
                             <Dialog open={warningOpen} onOpenChange={setWarningOpen}>
                                 <DialogContent showCloseIcon onOpenAutoFocus={e => e.preventDefault()}>
-                                    <h2 className="font-semibold">Key File Warning</h2>
+                                    <h2 className="font-semibold">Warning</h2>
                                     <p className="mt-4">
                                         Starting a ship with its key file should only be done once. Doing so repeatedly will
                                         break your ship and require a factory reset.

--- a/src/renderer/details/components/KeyfileField.tsx
+++ b/src/renderer/details/components/KeyfileField.tsx
@@ -63,7 +63,7 @@ export const KeyfileField: React.FC<KeyfileFieldProps> = ({ form, rules, childre
                                     <Question className="h-5 w-5 ml-3 fill-current opacity-25 cursor-help" />
                                 </Tooltip.Trigger>
                                 <Tooltip.Content side="top" className="px-3 py-2 max-w-md text-sm bg-gray-100 dark:bg-gray-800 rounded">
-                                    You can find your key file inside your Passport. If you don't have a key file, you can download it from Bridge.
+                                    You can find your key file inside your Passport. If you don't have one or are using another login option, you can download it from Bridge.
                                     <Tooltip.Arrow className="fill-current text-gray-100 dark:text-gray-800"/>
                                 </Tooltip.Content>
                             </Tooltip.Root>

--- a/src/renderer/details/components/KeyfileField.tsx
+++ b/src/renderer/details/components/KeyfileField.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
 import { Controller } from 'react-hook-form'
+import { Link } from 'react-router-dom'
 import { UseControllerOptions, UseFormMethods, Validate, ValidateResult } from 'react-hook-form/dist/types'
 import { send } from '../../client/ipc'
 import { AddPier } from '../../../background/services/pier-service'
+import { Dialog, DialogContent } from '../../shared/Dialog'
 
 interface KeyfileFieldProps {
     form: UseFormMethods<AddPier>
@@ -11,8 +13,10 @@ interface KeyfileFieldProps {
 }
 
 export const KeyfileField: React.FC<KeyfileFieldProps> = ({ form, rules, children }) => {
+    const [warningOpen, setWarningOpen] = React.useState(false)
 
-    async function setFile(onChange) {
+    async function bypassWarning(onChange) {
+        setWarningOpen(false)
         const file = await send('get-file')
         onChange(file);
     }
@@ -46,12 +50,27 @@ export const KeyfileField: React.FC<KeyfileFieldProps> = ({ form, rules, childre
                                 className="input flex-1 border border-r-0 rounded-r-none" 
                                 placeholder="/Users/my-user/sampel-palnet.key"
                                 readOnly={true}
-                                onClick={async () => await setFile(onChange)}
+                                onClick={() => setWarningOpen(true)}
                                 aria-invalid={!!form.errors?.keyFile} 
                             />
-                            <button type="button" className="input flex-none flex justify-center items-center hover:border-black focus:border-black dark:hover:border-white dark:focus:border-white default-ring rounded-l-none" onClick={async () => await setFile(onChange)}>
+                            <button type="button" className="input flex-none flex justify-center items-center hover:border-black focus:border-black dark:hover:border-white dark:focus:border-white default-ring rounded-l-none" onClick={() => setWarningOpen(true)}>
                                 Choose Key File
                             </button>
+                            <Dialog open={warningOpen} onOpenChange={setWarningOpen}>
+                                <DialogContent showCloseIcon onOpenAutoFocus={e => e.preventDefault()}>
+                                    <h2 className="font-semibold">Keyfile Warning</h2>
+                                    <p className="mt-4">
+                                        Starting a ship with it's keyfile should only be done once. Doing so repeatedly will
+                                        break your ship and require a factory reset.
+                                    </p>
+                                    <p className="mt-4">
+                                        If your keyfile has already been used, export your pier folder and <Link to="/boot/existing">boot as an existing ship</Link> instead.
+                                    </p>
+                                    <div className="mt-8 flex justify-center">
+                                        <button className="button border-yellow-200 text-yellow-200 hover:border-yellow-400 hover:text-yellow-400" onClick={async () => bypassWarning(onChange)}>Continue, this keyfile has not been used</button>
+                                    </div>
+                                </DialogContent>
+                            </Dialog>
                         </>
                     )}
                 />

--- a/src/renderer/details/components/ShipNameField.tsx
+++ b/src/renderer/details/components/ShipNameField.tsx
@@ -1,6 +1,10 @@
 import React from 'react'
+import { useQuery } from 'react-query';
+import { Link } from 'react-router-dom'
 import { UseFormMethods, Validate } from 'react-hook-form/dist/types'
-import { AddPier } from '../../../background/services/pier-service'
+import { Pier, AddPier } from '../../../background/services/pier-service'
+import { send } from '../../client/ipc';
+import { pierKey } from '../../query-keys';
 
 interface ShipNameFieldProps {
     form: UseFormMethods<AddPier>;
@@ -9,8 +13,14 @@ interface ShipNameFieldProps {
 }
 
 export const ShipNameField: React.FC<ShipNameFieldProps> = ({ form, validator, placeholder = '~sampel-palnet' }) => {
+    const { data: piers } = useQuery(pierKey(), () => send('get-piers'))
     const shipnamePattern = /^[a-z~-]*$/i;
     const shipnameContainsInvalidCharacters = form.errors.shipName?.type === 'pattern';
+
+    function getMatchingPier(shipName: string): Pier | undefined {
+        return piers.find(pier => pier.shipName.trim().toLowerCase() === shipName.toLowerCase())
+    }
+    const shipNameValidator = (value: string) => !getMatchingPier(value)
 
     return (
         <>
@@ -21,7 +31,7 @@ export const ShipNameField: React.FC<ShipNameFieldProps> = ({ form, validator, p
                 ref={form.register({ 
                     required: true,
                     pattern: shipnamePattern,
-                    validate: validator,
+                    validate: validator ? validator : shipNameValidator,
                     maxLength: 28
                 })}
                 className="input flex w-full mt-2" 
@@ -32,6 +42,11 @@ export const ShipNameField: React.FC<ShipNameFieldProps> = ({ form, validator, p
                 { form.errors.shipName?.type === 'required' && 'Ship name is required'}
                 { form.errors.shipName?.type === 'maxLength' && 'Ship name must be 28 characters or less'}
                 { (!form.errors.shipName || shipnameContainsInvalidCharacters) && 'Ship name must only contain alphanumeric, dash, underscore, or tilde characters' }
+                { form.errors.shipName?.type === 'validate' && 
+                    <span>
+                        A ship with this name <Link to={`/pier/${getMatchingPier(form.getValues().shipName).slug}`}>is already docked</Link> in Port.
+                    </span>
+                }
             </span>
         </>
     )

--- a/src/renderer/details/components/ShipNameField.tsx
+++ b/src/renderer/details/components/ShipNameField.tsx
@@ -18,7 +18,7 @@ export const ShipNameField: React.FC<ShipNameFieldProps> = ({ form, validator, p
     const shipnameContainsInvalidCharacters = form.errors.shipName?.type === 'pattern';
 
     function getMatchingPier(shipName: string): Pier | undefined {
-        return piers.find(pier => pier.shipName.trim().toLowerCase() === shipName.toLowerCase())
+        return piers.find(pier => pier.shipName?.trim().toLowerCase() === shipName.toLowerCase())
     }
     const shipNameValidator = (value: string) => !getMatchingPier(value)
 

--- a/src/renderer/icons/Question.tsx
+++ b/src/renderer/icons/Question.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export const Question = ({ className }: IconProps) => (
+  <svg xmlns="http://www.w3.org/2000/svg" className={className} viewBox="0 0 20 20">
+    <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113 8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" />
+  </svg>
+)

--- a/src/renderer/shared/Dialog.tsx
+++ b/src/renderer/shared/Dialog.tsx
@@ -4,7 +4,7 @@ import { Close } from '../icons/Close'
 
 export const Dialog: FC<RadixDialog.DialogOwnProps> = ({ children, ...props }) => (
     <RadixDialog.Root {...props}>
-        <RadixDialog.Overlay className="fixed z-10 top-0 left-0 right-0 bottom-0 bg-white dark:bg-black opacity-30" />
+        <RadixDialog.Overlay className="fixed z-10 top-0 left-0 right-0 bottom-0 bg-white dark:bg-black opacity-70" />
         { children }
     </RadixDialog.Root>
 )


### PR DESCRIPTION
closes https://github.com/urbit/port/issues/139

This pull request adds a few safety and help related features to boot configuration and key file submission.

- Detects when a user is trying to boot ships that are already in Port and prevents it with an error linking to the existing ship
- Adds a warning modal to the key file upload flow that the user must acknowledge
- New tooltip with details on where to find your key file

Help for finding a key file seemed distinct from the duplicate boot warning, so was appended as a tooltip rather than text within the modal. 

A few components from the boot pages are now requesting pier info independently. Performance wise, it seems fine right now, but we should maybe consider a refactor to streamline data flow sometime down the road.
