### PR TITLE
Display Ship Type

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "app-root-dir": "^1.0.2",
     "async": "^3.2.0",
     "axios": "^0.21.1",
-    "case": "^1.6.3",
     "classnames": "^2.3.1",
     "date-fns": "^2.19.0",
     "electron-context-menu": "^2.5.0",

--- a/src/renderer/ship/Ship.tsx
+++ b/src/renderer/ship/Ship.tsx
@@ -91,8 +91,18 @@ export const Ship: React.FC = () => {
                         <div className="mr-6">
                             <h1 className="font-semibold mb-1">
                                 <EditableShipName ship={ship} />
-                                <div className="mb-4 mt-2 whitespace-nowrap">{ ship.type === 'comet' ? getCometShortName(ship.shipName || '') : ship.shipName }</div>
                             </h1>
+                                <div className="mb-4 mt-2 whitespace-nowrap flex flex-row">
+                                    { ship.type !== 'remote'
+                                    ? (
+                                        <>
+                                            <div className="mr-2 capitalize font-semibold text-gray-400 dark:text-gray-500">{ship.type}</div>
+                                            <div className="font-medium text-gray-600 dark:text-gray-300">{ ship.type === 'comet' ? getCometShortName(ship.shipName || '') : ship.shipName }</div>
+                                        </>
+                                    ): (
+                                        <div className="font-normal text-gray-500 dark:text-gray-500">Remote ship</div>
+                                    )}
+                                </div>
                             <div className="flex items-center">
                                 <ShipStatus ship={ship} />
                                 {ship.status === 'running' && ship.type !== 'remote' && <button className="px-1 ml-3 font-semibold text-gray-300 dark:text-gray-700 hover:text-red-800 focus:text-red-800 hover:border-red-900 focus:border-red-900 rounded default-ring border border-gray-300 dark:border-gray-700 transition-colors" onClick={() => stopShip()}>Stop</button>}

--- a/src/renderer/ship/Ship.tsx
+++ b/src/renderer/ship/Ship.tsx
@@ -100,7 +100,7 @@ export const Ship: React.FC = () => {
                                             <div className="font-medium text-gray-600 dark:text-gray-300">{ ship.type === 'comet' ? getCometShortName(ship.shipName || '') : ship.shipName }</div>
                                         </>
                                     ): (
-                                        <div className="font-normal text-gray-500 dark:text-gray-500">Remote ship</div>
+                                        <div className="font-normal text-gray-600 dark:text-gray-400">Remote ship</div>
                                     )}
                                 </div>
                             <div className="flex items-center">

--- a/src/renderer/ship/components/ShipStatus.tsx
+++ b/src/renderer/ship/components/ShipStatus.tsx
@@ -1,6 +1,5 @@
 import * as Tooltip from '@radix-ui/react-tooltip';
 import React from 'react'
-import Case from 'case';
 import { Pier } from '../../../background/services/pier-service'
 
 const statusColors: Record<'running' | 'booting' | 'errored' | 'default', string> = {
@@ -10,33 +9,38 @@ const statusColors: Record<'running' | 'booting' | 'errored' | 'default', string
     default: 'bg-gray-300 dark:bg-gray-700'
 }
 
+const PortDisplay = ({ ship }: { ship: Pier }) => (
+    <>
+        <p className="mt-2 font-medium text-gray-600 dark:text-gray-400">Ports</p>
+        <div className="flex">
+            <span className="mr-3">Interface:</span>
+            <span className="font-mono ml-auto">{ ship.webPort }</span>
+        </div>
+        <div className="flex">
+            <span className="mr-3">Loopback:</span>
+            <span className="font-mono ml-auto">{ ship.loopbackPort }</span>
+        </div>
+    </>
+)
+
 export const ShipStatus = ({ ship }: { ship: Pier }) => {
     const isRemote = ship.type === 'remote';
-    let shipStatus = Case.capital(ship.status);
-
-    if (isRemote) {
-        shipStatus = 'Connected'
-    }
-
+    const isRunning = ship.status === 'running'
     return (
         <Tooltip.Root>
-            <Tooltip.Trigger className="default-ring cursor-default" disabled={isRemote}>
+            <Tooltip.Trigger className="default-ring cursor-default">
                 <span className="inline-flex items-center">
                     <span className={`inline-flex w-2 h-2 mr-1 rounded-full ${statusColors[ship.status] || statusColors.default}`}></span>
-                    <span className="text-gray-400 dark:text-gray-500">{shipStatus}</span>          
+                    <span className="capitalize text-gray-400 dark:text-gray-500">{ isRemote ? 'Connected' : ship.status }</span>
                 </span>
             </Tooltip.Trigger>
-            <Tooltip.Content side="top" className="px-3 py-2 text-sm bg-gray-100 dark:bg-gray-800 rounded">
-                <strong className="inline-block mb-1 font-bold">Ports</strong>
-                <div className="flex">
-                    <span className="mr-3">Interface:</span> 
-                    <span className="font-mono ml-auto">{ ship.webPort }</span>
-                </div>
-                <div className="flex">
-                    <span className="mr-3">Loopback:</span>
-                    <span className="font-mono ml-auto">{ ship.loopbackPort }</span>
-                </div>
-                <Tooltip.Arrow className="fill-current text-gray-100 dark:text-gray-800"/>
+            <Tooltip.Content side="top" className="px-3 py-2 text-sm bg-gray-200 dark:bg-gray-800 rounded">
+                <strong> { isRemote
+                    ? <span className="font-normal"> Remote ship </span>
+                    : <span className={isRunning ? 'capitalize font-semibold' : 'capitalize font-normal'}>{ship.type}</span>}
+                </strong>
+                { !isRemote && isRunning && <PortDisplay ship={ship} /> }
+                <Tooltip.Arrow className="fill-current text-gray-200 dark:text-gray-800"/>
             </Tooltip.Content>
         </Tooltip.Root>
     )


### PR DESCRIPTION
closes https://github.com/urbit/port/issues/145 

Adds support for showing ship type in a few locations. We don't currently have any icons for these (in Port or Landscape/Tlon world), but I'll keep an eye out and update this feature once we have a set.

Displayed in:
- In the ship status tooltip (can slot into ship list components with icons, but did not look good as text imo)
- On the manage ship page