### PR TITLE
Prevent Duplicate 'Running' Detection

### DIFF
--- a/src/background/services/pier-service.ts
+++ b/src/background/services/pier-service.ts
@@ -216,7 +216,7 @@ export class PierService {
         const check = await this.dojo(loopback, 'our')
         const webLive = await this.checkUrlAccessible(`http://localhost:${ports.web}`);
 
-        if (check && pier.shipName && check !== pier.shipName) {
+        if (check && pier.shipName && check !== pier.shipName.trim()) {
             // a different ship is running on this port
             return null
         }

--- a/src/background/services/pier-service.ts
+++ b/src/background/services/pier-service.ts
@@ -216,8 +216,9 @@ export class PierService {
         const check = await this.dojo(loopback, 'our')
         const webLive = await this.checkUrlAccessible(`http://localhost:${ports.web}`);
 
-        if (check && !pier.shipName) {
-            await this.updatePier(pier.slug, { shipName: check });
+        if (check && pier.shipName && check !== pier.shipName) {
+            // a different ship is running on this port
+            return null
         }
 
         if (check || webLive) {

--- a/src/background/services/pier-service.ts
+++ b/src/background/services/pier-service.ts
@@ -216,7 +216,7 @@ export class PierService {
         const check = await this.dojo(loopback, 'our')
         const webLive = await this.checkUrlAccessible(`http://localhost:${ports.web}`);
 
-        if (check && pier.shipName && check !== pier.shipName.trim()) {
+        if (check && pier.shipName && check.trim() !== pier.shipName.trim()) {
             // a different ship is running on this port
             return null
         }


### PR DESCRIPTION
coses #184

Previously, the running check used throughout the pier service looked for the `.http.ports` file and confirmed _something_ was running on the specified port. This PR simply modifies that check to ensure the ship name running matches the one it's looking for. This did successfully avoid the duplicate running issue when testing locally.

This change also removes a line which was being used to set the ship name if the current pier was missing it. Since in this situation we have no way of knowing if it is in fact the correct ship, I removed this line. This should be fine since ship name is mandatory for everything besides comets, who in turn have their name configured post-boot regardless of the deleted code.