### PR TITLE
Fix logging in with code

### DIFF
--- a/src/main/helpers.ts
+++ b/src/main/helpers.ts
@@ -98,7 +98,7 @@ function matchView(view: BrowserWindow | BrowserView, targetUrl: URL) {
   const path = view.webContents.getURL()
       .replace(`${targetUrl.protocol}//${targetUrl.host}`, '');
   isDev && console.log('attempting match', path, targetUrl.pathname)
-  return targetUrl.pathname.startsWith(path) || path.startsWith(targetUrl.pathname);
+  return targetUrl.pathname === path;
 }
 
 export function onNavigation({ urlTarget, currentUrl, preventDefault, createNewWindow, mainWindow, partition }: onNavigationParameters) {


### PR DESCRIPTION
closes #193 

View matching is overly broad leading to dropped navigations. Changing to exact match for now.

This will still catch opening the same app multiple times, but not different paths within apps. We need more sophisticated logic, but thinking we punt on that until the window service refactor.