### PR TITLE
Workflow Fixes

### DIFF
--- a/.github/workflows/ci-mac.yaml
+++ b/.github/workflows/ci-mac.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [ main ]
 jobs:
-  publish:
+  make:
     runs-on: macos-10.15
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish-mac.yaml
+++ b/.github/workflows/publish-mac.yaml
@@ -24,7 +24,8 @@ jobs:
           CERTIFICATE_PASSWORD: ${{ secrets.CERTIFICATE_PASSWORD }}
       - name: Build & Publish
         run: |
-          yarn run publish
+          yarn run publish publish --arch x64
+          yarn run publish --arch arm64
         env:
           APPLE_ID: ${{secrets.APPLE_ID}}
           APPLE_ID_PASSWORD: ${{secrets.APPLE_ID_PASSWORD}}

--- a/.github/workflows/publish-mac.yaml
+++ b/.github/workflows/publish-mac.yaml
@@ -24,7 +24,7 @@ jobs:
           CERTIFICATE_PASSWORD: ${{ secrets.CERTIFICATE_PASSWORD }}
       - name: Build & Publish
         run: |
-          yarn run publish publish --arch x64
+          yarn run publish --arch x64
           yarn run publish --arch arm64
         env:
           APPLE_ID: ${{secrets.APPLE_ID}}

--- a/.github/workflows/release-linux.yaml
+++ b/.github/workflows/release-linux.yaml
@@ -1,7 +1,7 @@
-name: Publish Linux
+name: Release Linux
 on:
-  push:
-    branches: [ main ]
+  release:
+    types: [published]
 jobs:
   publish:
     runs-on: ubuntu-18.04
@@ -26,6 +26,7 @@ jobs:
       - name: Build & Publish
         run: |
           yarn run publish
+          snapcraft upload --release=stable out/make/*.snap
         env:
           SNAPCRAFT_BUILD_ENVIRONMENT: host
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Fixes publishing for apple silicon builds and restricts uploading to snapcraft until after the release is published.

Worked on local publish dry runs, but will keep an eye out to make sure it's all functioning as expected after merging.