### PR TITLE
leave potential POST requests alone during navigation

### DIFF
--- a/src/main/helpers.ts
+++ b/src/main/helpers.ts
@@ -106,6 +106,11 @@ export function onNavigation({ urlTarget, currentUrl, preventDefault, createNewW
   let targetUrl = new URL(urlTarget);
   const isProtocolLink = targetUrl.protocol.startsWith(URBIT_PROTOCOL);
 
+  if (url.href === targetUrl.href) {
+    // could be a POST/PUT, don't interfere
+    return;
+  }
+
   if (isProtocolLink) {
     // fix protocol link being incorrectly parsed
     targetUrl = new URL(`${URBIT_PROTOCOL}://${url.host}/${targetUrl.host}${targetUrl.pathname}`)


### PR DESCRIPTION
Fixes the issue we talked about where old school form submissions to the same URL get swallowed (e.g. Rumors).