### PR TITLE
Fix blank screening

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "rules": {
-    "import/extensions": "off"
+    "import/extensions": "off",
+    "prefer-const": "off"
   },
   "env": {
     "browser": true,

--- a/src/background/services/pier-service.ts
+++ b/src/background/services/pier-service.ts
@@ -470,7 +470,7 @@ export class PierService {
         }, 5000)
     }
 
-    async stopPier(pier: Pier, stopWithSignal: boolean = false): Promise<Pier> {
+    async stopPier(pier: Pier, stopWithSignal = false): Promise<Pier> {
         let updatedPier;
         if (stopWithSignal && pier.status === 'running' && pier.pid && await this.processExists(pier.pid)) {
             // if we're only stopping via signal, we can speed up by using a heuristic instead of full check
@@ -518,7 +518,7 @@ export class PierService {
         await this.db.piers.asyncRemove({ slug: pier.slug })  
     }
 
-    private async stopUrbit(ship: Pier, stopWithSignal:boolean = false): Promise<void> {
+    private async stopUrbit(ship: Pier, stopWithSignal = false): Promise<void> {
         if (stopWithSignal || (ship.status === 'booting' && typeof ship.pid !== 'undefined')) {
             try {
                 process.kill(ship.pid, platform === 'win' ? 'SIGINT' : 'SIGTERM');

--- a/src/background/services/pier-service.ts
+++ b/src/background/services/pier-service.ts
@@ -264,20 +264,16 @@ export class PierService {
     }
 
     async checkPier(pier: Pier): Promise<Pier> {
-        if (pier.type === 'remote' || pier.startupPhase !== 'complete' || pier.status !== 'stopped')
+        if (pier.type === 'remote' || pier.startupPhase !== 'complete')
             return pier
 
         const ports = await this.runningCheck(pier);
 
-        if (ports) {
-            return await this.updatePier(pier.slug, {
-                webPort: ports.web,
-                loopbackPort: ports.loopback,
-                status: 'running'
-            });
-        }
-
-        return pier;
+        return await this.updatePier(pier.slug, {
+            webPort: ports?.web,
+            loopbackPort: ports?.loopback,
+            status: ports ? 'running' : 'stopped'
+        });
     }
 
     private async runningCheck(pier: Pier): Promise<PortSet | null> {
@@ -367,8 +363,8 @@ export class PierService {
             return await this.updatePier(checkedPier.slug, { lastUsed: (new Date()).toISOString() });
         }
 
-        booting = this.internalBootPier(pier);
-        this.bootingPiers.set(pier.slug, booting);
+        booting = this.internalBootPier(checkedPier);
+        this.bootingPiers.set(checkedPier.slug, booting);
         return booting;
     }
 


### PR DESCRIPTION
closes #217

During the boot overhaul work, I introduced a bug in `checkPier`. This led to false running detections and an unhandled error on view creation resulting in the blank screen. This is probably also the cause of the Windows funk I was mentioning in our last sync.

We received a few reports along these lines after shipping 1.9, but I didn't encounter this in my release testing so assumed it was related to the updated Urbit binaries (hanging blank screens are usually the result of arvo clogs). Going forward, I'll update my pre-release testing regimen to account for this possibility.

This fix can likely close a few other open issues, but I'll need to do more testing to confirm.